### PR TITLE
Clarified definition of total_terms_in_collection

### DIFF
--- a/src/main/java/io/osirrc/ciff/CommonIndexFileFormat.java
+++ b/src/main/java/io/osirrc/ciff/CommonIndexFileFormat.java
@@ -66,7 +66,8 @@ public final class CommonIndexFileFormat {
 
     /**
      * <pre>
-     * The total number of terms in the entire collection.
+     * The total number of terms in the entire collection. This is the sum of all document lengths of all documents in
+     * the collection.
      * </pre>
      *
      * <code>int64 total_terms_in_collection = 6;</code>
@@ -296,7 +297,8 @@ public final class CommonIndexFileFormat {
     private long totalTermsInCollection_;
     /**
      * <pre>
-     * The total number of terms in the entire collection.
+     * The total number of terms in the entire collection. This is the sum of all document lengths of all documents in
+     * the collection.
      * </pre>
      *
      * <code>int64 total_terms_in_collection = 6;</code>
@@ -987,7 +989,8 @@ public final class CommonIndexFileFormat {
       private long totalTermsInCollection_ ;
       /**
        * <pre>
-       * The total number of terms in the entire collection.
+       * The total number of terms in the entire collection. This is the sum of all document lengths of all documents in
+       * the collection.
        * </pre>
        *
        * <code>int64 total_terms_in_collection = 6;</code>
@@ -997,7 +1000,8 @@ public final class CommonIndexFileFormat {
       }
       /**
        * <pre>
-       * The total number of terms in the entire collection.
+       * The total number of terms in the entire collection. This is the sum of all document lengths of all documents in
+       * the collection.
        * </pre>
        *
        * <code>int64 total_terms_in_collection = 6;</code>
@@ -1010,7 +1014,8 @@ public final class CommonIndexFileFormat {
       }
       /**
        * <pre>
-       * The total number of terms in the entire collection.
+       * The total number of terms in the entire collection. This is the sum of all document lengths of all documents in
+       * the collection.
        * </pre>
        *
        * <code>int64 total_terms_in_collection = 6;</code>

--- a/src/main/protobuf/CommonIndexFileFormat.proto
+++ b/src/main/protobuf/CommonIndexFileFormat.proto
@@ -22,7 +22,8 @@ message Header {
   // The total number of documents in the collection; might differ from num_doc_records for a similar reason as above.
   int32 total_docs = 5;
 
-  // The total number of terms in the entire collection.
+  // The total number of terms in the entire collection. This is the sum of all document lengths of all documents in
+  // the collection.
   int64 total_terms_in_collection = 6;
 
   // The average document length. We store this value explicitly in case the exporting application wants a particular


### PR DESCRIPTION
@andrewtrotman requested clarification of `total_terms_in_collection` in header, which was not included in previous commit. Adding now.
