### PR TITLE
Remove incorrect information from the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,6 @@ We provide a full guide on how to replicate the above results [here](anserini-ex
 
 A CIFF export can be ingested into a number of different search systems.
 
-+ [PISA](https://github.com/pisa-engine/pisa) via the [PISA CIFF Binaries](https://github.com/pisa-engine/ciff) (includes Python and Rust versions).
++ [PISA](https://github.com/pisa-engine/pisa) via the [PISA CIFF Binaries](https://github.com/pisa-engine/ciff).
 
 


### PR DESCRIPTION
PISA has deprecated the CPP and Python exporters in favour of a Rust tool, so the README here should now reflect that.