### PR TITLE
Checks total_terms_in_collection against sum of all doc_lengths

### DIFF
--- a/src/main/java/io/osirrc/ciff/ReadCIFF.java
+++ b/src/main/java/io/osirrc/ciff/ReadCIFF.java
@@ -62,28 +62,28 @@ public class ReadCIFF {
     CommonIndexFileFormat.Header header = CommonIndexFileFormat.Header.parseDelimitedFrom(fileIn);
 
     System.out.println("=== Header === ");
-    System.out.println(String.format("version: %d", header.getVersion()));
-    System.out.println(String.format("num_postings_lists: %d", header.getNumPostingsLists()));
-    System.out.println(String.format("num_doc_records: %d", header.getNumDocs()));
-    System.out.println(String.format("total_postings_lists: %d", header.getTotalPostingsLists()));
-    System.out.println(String.format("total_docs: %d", header.getTotalDocs()));
-    System.out.println(String.format("total_terms_in_collection: %d", header.getTotalTermsInCollection()));
+    System.out.println(String.format("version: %,d", header.getVersion()));
+    System.out.println(String.format("num_postings_lists: %,d", header.getNumPostingsLists()));
+    System.out.println(String.format("num_doc_records: %,d", header.getNumDocs()));
+    System.out.println(String.format("total_postings_lists: %,d", header.getTotalPostingsLists()));
+    System.out.println(String.format("total_docs: %,d", header.getTotalDocs()));
+    System.out.println(String.format("total_terms_in_collection: %,d", header.getTotalTermsInCollection()));
     System.out.println(String.format("average_doclength: %f", header.getAverageDoclength()));
     System.out.println(String.format("description: %s", header.getDescription()));
     System.out.println();
 
-    System.out.println(String.format("Expecting %d postings lists and %d doc records in this export.",
+    System.out.println(String.format("Expecting %,d postings lists and %,d doc records in this export.",
         header.getNumPostingsLists(), header.getNumDocs()));
 
     for (int i=0; i<header.getNumPostingsLists(); i++ ) {
       CommonIndexFileFormat.PostingsList pl = CommonIndexFileFormat.PostingsList.parseDelimitedFrom(fileIn);
       if (pl.getDf() != pl.getPostingsCount()) {
         throw new RuntimeException(String.format(
-            "Unexpected number of postings! expected %d got %d", pl.getDf(), pl.getPostingsCount()));
+            "Unexpected number of postings! expected %,d got %,d", pl.getDf(), pl.getPostingsCount()));
       }
 
       if (i % args.dumpInterval == 0) {
-        System.out.print(String.format("term: '%s', df=%d, cf=%d", pl.getTerm(), pl.getDf(), pl.getCf()));
+        System.out.print(String.format("term: '%s', df=%,d, cf=%,d", pl.getTerm(), pl.getDf(), pl.getCf()));
 
         for (int j = 0; j < (pl.getDf() > 10 ? 10 : pl.getDf()); j++) {
           System.out.print(String.format(" (%d, %d)", pl.getPostings(j).getDocid(), pl.getPostings(j).getTf()));
@@ -92,12 +92,22 @@ public class ReadCIFF {
       }
     }
 
+    long totalTermsInCollection = 0; // Should be sum of doclengths.
     for (int i=0; i<header.getNumDocs(); i++) {
       CommonIndexFileFormat.DocRecord docRecord = CommonIndexFileFormat.DocRecord.parseDelimitedFrom(fileIn);
       if (i % args.dumpInterval == 0) {
-        System.out.println(String.format("%d\t%s\t%d", docRecord.getDocid(), docRecord.getCollectionDocid(), docRecord.getDoclength()));
+        System.out.println(String.format(
+            "%d\t%s\t%d", docRecord.getDocid(), docRecord.getCollectionDocid(), docRecord.getDoclength()));
       }
+      totalTermsInCollection += docRecord.getDoclength();
     }
+
+    if (totalTermsInCollection != header.getTotalTermsInCollection()) {
+      System.err.println(String.format("Warning: 'total_terms_in_collection' field in header" +
+              " %,d does not match sum of doclengths from DocRecord messages %,d!",
+          header.getTotalTermsInCollection(), totalTermsInCollection));
+    }
+
     fileIn.close();
   }
 }

--- a/src/main/java/io/osirrc/ciff/ReadCIFF.java
+++ b/src/main/java/io/osirrc/ciff/ReadCIFF.java
@@ -123,7 +123,7 @@ public class ReadCIFF {
       System.out.print("[PASSED]\n");
     } else {
       System.out.print(String.format("[FAILED] %,d vs. %,d\n",
-          header.getTotalTermsInCollection(), totalTermsInCollection));
+          header.getTotalTermsInCollection(), sumOfAllTfs));
     }
 
     fileIn.close();


### PR DESCRIPTION
ref: #2 

Result running on `robust04`:

```
$ target/appassembler/bin/ReadCIFF -input robust04-complete-20200306.ciff.gz
Reading header...
=== Header === 
version: 1
num_postings_lists: 923,436
num_doc_records: 528,030
total_postings_lists: 923,436
total_docs: 528,030
total_terms_in_collection: 174,540,872
average_doclength: 330.551052
description: Anserini v0.7.2, Robust04 regression

Expecting 923,436 postings lists and 528,030 doc records in this export.
term: '0', df=10,826, cf=33,491 (64, 1) (4, 1) (49, 1) (72, 1) (8, 2) (2, 2) (35, 1) (2, 3) (10, 2) (41, 3) ...
term: '16_limit', df=1, cf=1 (122036, 1)
term: '33938', df=1, cf=1 (85330, 1)
term: '70lajita', df=1, cf=1 (88488, 1)
term: 'badman', df=5, cf=7 (74419, 1) (62978, 3) (66584, 1) (3491, 1) (57526, 1)
term: 'e:graphicsen26oc94.004', df=1, cf=1 (187838, 1)
term: 'jiarngsu', df=1, cf=1 (314707, 1)
term: 'netherla', df=1, cf=1 (211967, 1)
term: 'sedar', df=2, cf=2 (142895, 1) (165749, 1)
term: 'wouldembark', df=1, cf=1 (95361, 1)
0	LA111289-0001	792
100000	FT921-5743	104
200000	FT944-9315	64
300000	FT921-1042	280
400000	FT942-8502	64
500000	LA030889-0074	64
Warning: 'total_terms_in_collection' field in header 174,540,872 does not match sum of doclengths from DocRecord messages 167,686,911!
```

Result running on `cw12b`:

```
$ target/appassembler/bin/ReadCIFF -input cw12b-complete-20200309.ciff.gz -dumpInterval 50000000
Reading header...
=== Header === 
version: 1
num_postings_lists: 201,846,459
num_doc_records: 52,249,039
total_postings_lists: 201,846,459
total_docs: 52,249,039
total_terms_in_collection: 30,666,923,268
average_doclength: 586.937556
description: Anserini v0.7.2, ClueWeb12-B13 regression

Expecting 201,846,459 postings lists and 52,249,039 doc records in this export.
term: '#⃣', df=5, cf=6 (5145091, 1) (8973234, 1) (7234714, 1) (10811742, 1) (6892163, 2)
term: '4045462157', df=1, cf=1 (17759034, 1)
term: 'comments.gwatrace1', df=2, cf=2 (19228365, 1) (775825, 1)
term: 'nffstvgsdefspffn', df=1, cf=2 (3603517, 2)
term: 'звучат', df=45, cf=50 (17118, 1) (3070019, 1) (43344, 1) (819663, 1) (1576958, 1) (5429140, 3) (3302904, 1) (3408154, 1) (49513, 1) (266904, 1) ...
0	clueweb12-0701wb-62-07693	248
50000000	clueweb12-0815wb-86-06812	168
Warning: 'total_terms_in_collection' field in header 30,666,923,268 does not match sum of doclengths from DocRecord messages 29,407,141,065!
```
