### PR TITLE
Term name for freq readers uses args.contentsField

### DIFF
--- a/src/main/java/io/osirrc/ciff/lucene/ExportAnseriniLuceneIndex.java
+++ b/src/main/java/io/osirrc/ciff/lucene/ExportAnseriniLuceneIndex.java
@@ -181,7 +181,7 @@ public class ExportAnseriniLuceneIndex {
         continue;
       }
 
-      Term term = new Term("contents", token);
+      Term term = new Term(args.contentsField, token);
       long df = reader.docFreq(term);
       long cf = reader.totalTermFreq(term);
 


### PR DESCRIPTION
After switching this from hard-coded to arg, I was able to use the `contentsField` arg and export a ciff file using a custom field name as I expected.